### PR TITLE
Strip user ID from question

### DIFF
--- a/clementine/slack_client.py
+++ b/clementine/slack_client.py
@@ -62,8 +62,9 @@ class SlackEvent:
             "what is tekton?" -> "what is tekton?"
         """
         # Pattern to match Slack user mentions at the start of text
-        # <@U followed by alphanumeric characters, then >
-        mention_pattern = r'^<@U[A-Za-z0-9]+>\s*'
+        # <@U or <@W followed by alphanumeric characters, underscores, or hyphens, then >
+        # Slack user IDs can start with U (regular users) or W (Enterprise users)
+        mention_pattern = r'^<@[UW][A-Za-z0-9_-]+>\s*'
         return re.sub(mention_pattern, '', text).strip()
 
 

--- a/clementine/slack_client.py
+++ b/clementine/slack_client.py
@@ -63,7 +63,7 @@ class SlackEvent:
         """
         # Pattern to match Slack user mentions at the start of text
         # <@U followed by alphanumeric characters, then >
-        mention_pattern = r'^<@U[A-Z0-9]+>\s*'
+        mention_pattern = r'^<@U[A-Za-z0-9]+>\s*'
         return re.sub(mention_pattern, '', text).strip()
 
 

--- a/tests/test_slack_client.py
+++ b/tests/test_slack_client.py
@@ -74,6 +74,57 @@ class TestSlackEvent:
         
         with pytest.raises(ValueError, match="Event text cannot be empty"):
             SlackEvent.from_dict(event_dict)
+    
+    def test_strips_bot_mention_from_text(self):
+        """Test that bot mentions are stripped from the beginning of text."""
+        event_dict = {
+            "text": "<@U098PF40S1E> what is tekton?",
+            "user": "U123456",
+            "channel": "C789012",
+            "ts": "1234567890.123"
+        }
+        
+        event = SlackEvent.from_dict(event_dict)
+        
+        assert event.text == "what is tekton?"
+    
+    def test_strips_bot_mention_with_extra_whitespace(self):
+        """Test that bot mentions and extra whitespace are properly stripped."""
+        event_dict = {
+            "text": "<@U098PF40S1E>   what is tekton?",
+            "user": "U123456",
+            "channel": "C789012",
+            "ts": "1234567890.123"
+        }
+        
+        event = SlackEvent.from_dict(event_dict)
+        
+        assert event.text == "what is tekton?"
+    
+    def test_text_without_bot_mention_unchanged(self):
+        """Test that text without bot mention at start is unchanged."""
+        event_dict = {
+            "text": "what is tekton?",
+            "user": "U123456",
+            "channel": "C789012",
+            "ts": "1234567890.123"
+        }
+        
+        event = SlackEvent.from_dict(event_dict)
+        
+        assert event.text == "what is tekton?"
+    
+    def test_error_when_only_bot_mention(self):
+        """Test error when text contains only bot mention."""
+        event_dict = {
+            "text": "<@U098PF40S1E>",
+            "user": "U123456",
+            "channel": "C789012",
+            "ts": "1234567890.123"
+        }
+        
+        with pytest.raises(ValueError, match="Event text cannot be empty after removing bot mention"):
+            SlackEvent.from_dict(event_dict)
 
 
 class TestSlackClient:

--- a/tests/test_slack_client.py
+++ b/tests/test_slack_client.py
@@ -125,6 +125,45 @@ class TestSlackEvent:
         
         with pytest.raises(ValueError, match="Event text cannot be empty after removing bot mention"):
             SlackEvent.from_dict(event_dict)
+    
+    def test_strips_enterprise_user_mention(self):
+        """Test that Enterprise user mentions (W prefix) are stripped."""
+        event_dict = {
+            "text": "<@W098PF40S1E> what is enterprise slack?",
+            "user": "U123456",
+            "channel": "C789012",
+            "ts": "1234567890.123"
+        }
+        
+        event = SlackEvent.from_dict(event_dict)
+        
+        assert event.text == "what is enterprise slack?"
+    
+    def test_strips_user_mention_with_underscores_and_hyphens(self):
+        """Test that user mentions with underscores and hyphens are stripped."""
+        event_dict = {
+            "text": "<@U098_PF-40S1E> what is tekton?",
+            "user": "U123456",
+            "channel": "C789012",
+            "ts": "1234567890.123"
+        }
+        
+        event = SlackEvent.from_dict(event_dict)
+        
+        assert event.text == "what is tekton?"
+    
+    def test_mixed_case_user_id_stripped(self):
+        """Test that user mentions with mixed case characters are stripped."""
+        event_dict = {
+            "text": "<@U098pF40s1E> what is tekton?",
+            "user": "U123456",
+            "channel": "C789012",
+            "ts": "1234567890.123"
+        }
+        
+        event = SlackEvent.from_dict(event_dict)
+        
+        assert event.text == "what is tekton?"
 
 
 class TestSlackClient:


### PR DESCRIPTION
Because of the way the slack API works we were getting the user ID embedded in the question text by mistake.