### PR TITLE
Add slack questions

### DIFF
--- a/SLACK_QUESTIONS_FEATURE.md
+++ b/SLACK_QUESTIONS_FEATURE.md
@@ -1,0 +1,67 @@
+# Slack Context Questions Feature
+
+This document describes the new Slack context questions feature that allows users to ask questions about the current Slack channel context.
+
+## Usage
+
+Use the `/clementine slack <question>` command to ask questions about the current channel's conversation history.
+
+### Examples
+
+```
+/clementine slack what are andrew and psav talking about re: clowder
+/clementine slack what was the main decision made in this channel today?
+/clementine slack can you summarize the discussion about the API changes?
+```
+
+### User Name Display
+
+The bot now displays real user names instead of user IDs in the conversation context, making it easier to ask questions about specific people. For example:
+
+- Instead of: "User U123456: Hello everyone"  
+- You'll see: "Andrew Chen: Hello everyone"
+
+This allows you to ask natural questions like "what are andrew and psav talking about?" rather than having to use cryptic user IDs.
+
+## How It Works
+
+1. **Context Extraction**: When you ask a question, the bot retrieves recent messages from the current channel
+2. **Advanced Chat API**: The conversation history is sent as "chunks" to the advanced chat API using the "bring your own chunks" feature with the "clowder" assistant
+3. **Question Answering**: The LLM uses the channel context to answer your question
+4. **Response Formatting**: The answer is formatted and posted back to Slack
+
+## Architecture
+
+The feature is implemented using clean OOP principles with separate responsibilities:
+
+### New Classes
+
+- **`SlackContextExtractor`**: Retrieves channel and thread history from Slack
+- **`AdvancedChatClient`**: Handles communication with the "bring your own chunks" API  
+- **`SlackQuestionBot`**: Orchestrates the complete workflow
+- **`ChunksRequest`**: Value object for advanced chat API requests
+
+### Design Principles
+
+- **Single Responsibility**: Each class has one clear purpose
+- **No Conditionals**: New classes were created instead of adding complexity to existing ones
+- **Dependency Injection**: Classes depend on abstractions, not concrete implementations
+- **Error Handling**: Comprehensive error handling throughout the workflow
+
+## Configuration
+
+No additional configuration is required. The feature uses the existing Tangerine API configuration.
+
+## Limitations
+
+- Only retrieves recent channel history (configurable, default 50 messages)
+- Works with channel history, not private DMs
+- Requires appropriate Slack permissions for message history access
+
+## Testing
+
+Comprehensive test coverage includes:
+- Unit tests for all new classes
+- Integration scenarios
+- Error handling paths
+- Mock-based testing to avoid external dependencies

--- a/clementine/advanced_chat_client.py
+++ b/clementine/advanced_chat_client.py
@@ -1,0 +1,103 @@
+"""Advanced chat client for 'bring your own chunks' API."""
+
+import requests
+import uuid
+import logging
+import json
+from typing import Dict, List
+from dataclasses import dataclass
+
+from .tangerine import TangerineResponse
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ChunksRequest:
+    """Value object for advanced chat requests with custom chunks."""
+    query: str
+    chunks: List[str]
+    session_id: str
+    client_name: str
+    assistant_name: str = "clowder"
+    
+    def to_payload(self) -> Dict:
+        """Convert to API payload format."""
+        return {
+            "assistants": [self.assistant_name],
+            "query": self.query,
+            "sessionId": self.session_id,
+            "interactionId": str(uuid.uuid4()),
+            "client": self.client_name,
+            "stream": False,
+            "chunks": self.chunks,
+            "disable_agentic": True
+        }
+
+
+class AdvancedChatClient:
+    """Handles communication with the advanced chat API using custom chunks.
+    
+    This client is specifically designed for the 'bring your own chunks' workflow
+    where we provide our own context instead of using traditional RAG retrieval.
+    It follows the single responsibility principle by only handling API communication.
+    """
+    
+    def __init__(self, api_url: str, api_token: str, timeout: int = 500):
+        if not api_url or not api_token:
+            raise ValueError("Both api_url and api_token are required")
+        
+        self.api_url = api_url.rstrip('/')  # Remove trailing slash
+        self.api_token = api_token
+        self.timeout = timeout
+        self.chat_endpoint = f"{self.api_url}/api/assistants/chat"
+    
+    def chat_with_chunks(self, chunks_request: ChunksRequest) -> TangerineResponse:
+        """Send chat request with custom chunks and return structured response."""
+        logger.debug("Sending chunks-based chat request for session %s", chunks_request.session_id)
+        logger.debug("Using %d chunks for context", len(chunks_request.chunks))
+        
+        payload = chunks_request.to_payload()
+        
+        # Log payload without chunks for debugging (chunks could be large)
+        debug_payload = {k: v for k, v in payload.items() if k != "chunks"}
+        debug_payload["chunks"] = f"[{len(payload['chunks'])} chunks]"
+        logger.debug("API payload: %s", debug_payload)
+        
+        response_data = self._make_request(payload)
+        logger.debug("Received response from advanced chat API")
+        
+        # Extract interaction_id from the payload we sent
+        interaction_id = payload["interactionId"]
+        return TangerineResponse.from_dict(response_data, interaction_id)
+    
+    def _make_request(self, payload: Dict) -> Dict:
+        """Make HTTP request to advanced chat API with comprehensive error handling."""
+        try:
+            response = requests.post(
+                self.chat_endpoint,
+                headers={
+                    "Authorization": f"Bearer {self.api_token}",
+                    "Content-Type": "application/json"
+                },
+                json=payload,
+                timeout=self.timeout
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.Timeout:
+            logger.error("Advanced chat API request timed out after %d seconds", self.timeout)
+            raise
+        except requests.exceptions.ConnectionError:
+            logger.error("Failed to connect to advanced chat API at %s", self.chat_endpoint)
+            raise
+        except requests.exceptions.HTTPError as e:
+            status_code = getattr(e.response, 'status_code', 'unknown') if e.response else 'unknown'
+            logger.error("Advanced chat API returned HTTP error %s: %s", status_code, e)
+            raise
+        except json.JSONDecodeError:
+            logger.error("Advanced chat API returned invalid JSON response")
+            raise
+        except Exception as e:
+            logger.error("Unexpected error calling advanced chat API: %s", e)
+            raise

--- a/clementine/slack_context_extractor.py
+++ b/clementine/slack_context_extractor.py
@@ -1,0 +1,163 @@
+"""Slack context extraction for question answering."""
+
+import logging
+from typing import List, Optional
+from dataclasses import dataclass
+from slack_sdk.errors import SlackApiError
+from slack_sdk.web.client import WebClient
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SlackMessage:
+    """Value object representing a Slack message for context."""
+    text: str
+    user_id: str
+    timestamp: str
+    user_name: Optional[str] = None
+    thread_ts: Optional[str] = None
+    
+    def to_context_string(self) -> str:
+        """Convert message to a context string for LLM consumption."""
+        # Use real name if available, otherwise fall back to user ID
+        display_name = self.user_name or self.user_id
+        return f"{display_name}: {self.text}"
+
+
+class SlackContextExtractor:
+    """Extracts Slack channel/thread context for question answering.
+    
+    This class follows the single responsibility principle by only handling
+    the extraction of Slack conversation context. It doesn't know about
+    LLM APIs or question processing.
+    """
+    
+    def __init__(self, client: WebClient, max_messages: int = 50):
+        self.client = client
+        self.max_messages = max_messages
+        self._user_name_cache = {}  # Cache user names to avoid repeated API calls
+    
+    def extract_thread_context(self, channel: str, thread_ts: str) -> List[str]:
+        """Extract context from a specific thread.
+        
+        Args:
+            channel: Slack channel ID
+            thread_ts: Thread timestamp
+            
+        Returns:
+            List of context strings suitable for LLM consumption
+        """
+        try:
+            logger.debug("Extracting thread context for channel %s, thread %s", channel, thread_ts)
+            
+            response = self.client.conversations_replies(
+                channel=channel,
+                ts=thread_ts,
+                limit=self.max_messages
+            )
+            
+            messages = response.get("messages", [])
+            logger.debug("Retrieved %d messages from thread", len(messages))
+            
+            return self._messages_to_context(messages)
+            
+        except SlackApiError as e:
+            logger.error("Failed to extract thread context: %s", e)
+            return []
+    
+    def extract_channel_context(self, channel: str, limit: Optional[int] = None) -> List[str]:
+        """Extract context from recent channel history.
+        
+        Args:
+            channel: Slack channel ID
+            limit: Maximum number of messages to retrieve (defaults to max_messages)
+            
+        Returns:
+            List of context strings suitable for LLM consumption
+        """
+        try:
+            limit = limit or self.max_messages
+            logger.debug("Extracting channel context for channel %s, limit %d", channel, limit)
+            
+            response = self.client.conversations_history(
+                channel=channel,
+                limit=limit
+            )
+            
+            messages = response.get("messages", [])
+            # Reverse to get chronological order (Slack returns newest first)
+            messages.reverse()
+            
+            logger.debug("Retrieved %d messages from channel", len(messages))
+            
+            return self._messages_to_context(messages)
+            
+        except SlackApiError as e:
+            logger.error("Failed to extract channel context: %s", e)
+            return []
+    
+    def _messages_to_context(self, messages: List[dict]) -> List[str]:
+        """Convert Slack messages to context strings.
+        
+        Filters out bot messages and system messages, keeping only
+        relevant human conversation.
+        """
+        context_strings = []
+        
+        for message in messages:
+            # Skip bot messages and system messages
+            if message.get("bot_id") or message.get("subtype"):
+                continue
+                
+            # Skip messages without text
+            text = message.get("text", "").strip()
+            if not text:
+                continue
+            
+            user_id = message.get("user", "unknown")
+            user_name = self._get_user_name(user_id)
+            
+            slack_message = SlackMessage(
+                text=text,
+                user_id=user_id,
+                timestamp=message.get("ts", ""),
+                user_name=user_name,
+                thread_ts=message.get("thread_ts")
+            )
+            
+            context_strings.append(slack_message.to_context_string())
+        
+        logger.debug("Converted %d messages to %d context strings", len(messages), len(context_strings))
+        return context_strings
+    
+    def _get_user_name(self, user_id: str) -> Optional[str]:
+        """Get user display name from Slack API with caching."""
+        if not user_id or user_id == "unknown":
+            return None
+            
+        # Check cache first
+        if user_id in self._user_name_cache:
+            return self._user_name_cache[user_id]
+        
+        try:
+            response = self.client.users_info(user=user_id)
+            user_info = response.get("user", {})
+            
+            # Try to get real name first, then display name, then fall back to user ID
+            real_name = user_info.get("real_name", "").strip()
+            display_name = user_info.get("profile", {}).get("display_name", "").strip()
+            username = user_info.get("name", "").strip()
+            
+            # Prefer real name, then display name, then username
+            user_name = real_name or display_name or username or user_id
+            
+            # Cache the result
+            self._user_name_cache[user_id] = user_name
+            return user_name
+            
+        except SlackApiError as e:
+            logger.warning("Failed to get user info for %s: %s", user_id, e)
+            # Cache the failure to avoid repeated API calls
+            self._user_name_cache[user_id] = None
+            return None

--- a/clementine/slack_question_bot.py
+++ b/clementine/slack_question_bot.py
@@ -1,0 +1,130 @@
+"""Slack question bot for answering questions about channel context."""
+
+import logging
+from typing import Dict, Union
+from slack_sdk.web.client import WebClient
+
+from .slack_client import SlackClient
+from .slack_context_extractor import SlackContextExtractor
+from .advanced_chat_client import AdvancedChatClient, ChunksRequest
+from .tangerine import generate_session_id
+from .formatters import ResponseFormatter, MessageFormatter
+from .error_handling import ErrorHandler
+
+logger = logging.getLogger(__name__)
+
+
+class SlackQuestionBot:
+    """Bot for answering questions about Slack channel context.
+    
+    This class orchestrates the entire workflow of:
+    1. Extracting context from Slack channels/threads
+    2. Sending questions with context to the advanced chat API
+    3. Formatting and posting responses back to Slack
+    
+    It follows the single responsibility principle by focusing only on
+    the Slack context question workflow.
+    """
+    
+    def __init__(self, 
+                 slack_client: SlackClient,
+                 context_extractor: SlackContextExtractor,
+                 advanced_chat_client: AdvancedChatClient,
+                 bot_name: str,
+                 formatter: ResponseFormatter = None):
+        self.slack_client = slack_client
+        self.context_extractor = context_extractor
+        self.advanced_chat_client = advanced_chat_client
+        self.bot_name = bot_name
+        self.formatter = formatter or MessageFormatter()
+        self.error_handler = ErrorHandler(bot_name)
+    
+    def handle_question(self, question: str, channel: str, thread_ts: str, 
+                       user_id: str, slack_web_client: WebClient) -> None:
+        """Handle a question about the current Slack context.
+        
+        Args:
+            question: The user's question
+            channel: Slack channel ID
+            thread_ts: Thread timestamp (may be None for channel questions)
+            user_id: User who asked the question
+            slack_web_client: Slack web client for posting responses
+        """
+        logger.info("Processing Slack context question from user %s in channel %s", user_id, channel)
+        
+        # Post loading message
+        loading_ts = self.slack_client.post_loading_message(channel, thread_ts)
+        if not loading_ts:
+            logger.warning("Failed to post loading message, aborting question handling")
+            return
+        
+        try:
+            # Extract context from Slack
+            context_chunks = self._extract_context(channel, thread_ts)
+            
+            if not context_chunks:
+                error_message = "I couldn't find any recent conversation context to answer your question about."
+                self._update_message_with_error(channel, loading_ts, error_message)
+                return
+            
+            # Get response from advanced chat API
+            response = self._get_chat_response(question, context_chunks, channel, thread_ts)
+            
+            # Format and post response
+            formatted_message = self.formatter.format_with_sources(response)
+            self._update_message(channel, loading_ts, formatted_message)
+            
+            logger.info("Successfully handled Slack context question for user %s", user_id)
+            
+        except Exception as error:
+            logger.error("Error handling Slack context question: %s", error)
+            error_message = self.error_handler.format_error_message(error)
+            self._update_message_with_error(channel, loading_ts, error_message)
+    
+    def _extract_context(self, channel: str, thread_ts: str) -> list[str]:
+        """Extract context from Slack channel or thread."""
+        if thread_ts:
+            # Extract from specific thread
+            logger.debug("Extracting context from thread %s", thread_ts)
+            return self.context_extractor.extract_thread_context(channel, thread_ts)
+        else:
+            # Extract from recent channel history
+            logger.debug("Extracting context from channel %s", channel)
+            return self.context_extractor.extract_channel_context(channel)
+    
+    def _get_chat_response(self, question: str, context_chunks: list[str], 
+                          channel: str, thread_ts: str):
+        """Get response from advanced chat API using context chunks."""
+        # Create deterministic session ID
+        session_id = generate_session_id(channel, thread_ts or channel)
+        
+        chunks_request = ChunksRequest(
+            query=question,
+            chunks=context_chunks,
+            session_id=session_id,
+            client_name=self.bot_name
+        )
+        
+        logger.debug("Requesting response from advanced chat API with %d chunks", 
+                    len(context_chunks))
+        return self.advanced_chat_client.chat_with_chunks(chunks_request)
+    
+    def _update_message(self, channel: str, ts: str, formatted_message: Union[str, Dict]) -> None:
+        """Update Slack message with response (text or Block Kit)."""
+        if isinstance(formatted_message, dict):
+            # Block Kit message
+            success = self.slack_client.update_message_with_blocks(
+                channel, ts, formatted_message
+            )
+        else:
+            # Plain text message
+            success = self.slack_client.update_message(channel, ts, formatted_message)
+        
+        if not success:
+            logger.warning("Failed to update message %s in channel %s", ts, channel)
+    
+    def _update_message_with_error(self, channel: str, ts: str, error_message: str) -> None:
+        """Update message with error text."""
+        success = self.slack_client.update_message(channel, ts, error_message)
+        if not success:
+            logger.warning("Failed to update message %s with error in channel %s", ts, channel)

--- a/clementine/tangerine.py
+++ b/clementine/tangerine.py
@@ -110,7 +110,8 @@ class TangerineClient:
             "interactionId": str(uuid.uuid4()),
             "client": client_name,
             "stream": False,
-            "prompt": prompt
+            "prompt": prompt,
+            "disable_agentic": True
         }
     
     def _make_request(self, payload: Dict) -> Dict:

--- a/tests/test_advanced_chat_client.py
+++ b/tests/test_advanced_chat_client.py
@@ -1,0 +1,197 @@
+"""Tests for AdvancedChatClient."""
+
+import pytest
+import requests
+import json
+from unittest.mock import Mock, patch
+from uuid import UUID
+
+from clementine.advanced_chat_client import AdvancedChatClient, ChunksRequest
+from clementine.tangerine import TangerineResponse
+
+
+class TestChunksRequest:
+    """Test ChunksRequest value object."""
+    
+    def test_to_payload(self):
+        """Test converting request to API payload."""
+        chunks_request = ChunksRequest(
+            query="What are they talking about?",
+            chunks=["User A: Hello", "User B: Hi there"],
+            session_id="session-123",
+            client_name="test-client"
+        )
+        
+        payload = chunks_request.to_payload()
+        
+        assert payload["assistants"] == ["clowder"]
+        assert payload["query"] == "What are they talking about?"
+        assert payload["chunks"] == ["User A: Hello", "User B: Hi there"]
+        assert payload["sessionId"] == "session-123"
+        assert payload["client"] == "test-client"
+        assert payload["stream"] is False
+        assert payload["disable_agentic"] is True
+        
+        # Check that interactionId is a valid UUID
+        assert UUID(payload["interactionId"])
+    
+    def test_to_payload_custom_assistant(self):
+        """Test converting request to API payload with custom assistant name."""
+        chunks_request = ChunksRequest(
+            query="Test question",
+            chunks=["chunk1"],
+            session_id="session-123",
+            client_name="test-client",
+            assistant_name="customAssistant"
+        )
+        
+        payload = chunks_request.to_payload()
+        
+        assert payload["assistants"] == ["customAssistant"]
+        assert payload["disable_agentic"] is True
+
+
+class TestAdvancedChatClient:
+    """Test AdvancedChatClient functionality."""
+    
+    @pytest.fixture
+    def client(self):
+        """Create AdvancedChatClient for testing."""
+        return AdvancedChatClient(
+            api_url="https://api.example.com",
+            api_token="test-token",
+            timeout=30
+        )
+    
+    def test_init_validates_parameters(self):
+        """Test initialization parameter validation."""
+        # Valid initialization
+        client = AdvancedChatClient("https://api.example.com", "token")
+        assert client.api_url == "https://api.example.com"
+        assert client.api_token == "token"
+        assert client.timeout == 500  # default
+        
+        # Invalid parameters
+        with pytest.raises(ValueError, match="Both api_url and api_token are required"):
+            AdvancedChatClient("", "token")
+        
+        with pytest.raises(ValueError, match="Both api_url and api_token are required"):
+            AdvancedChatClient("https://api.example.com", "")
+    
+    def test_init_strips_trailing_slash(self):
+        """Test that trailing slash is removed from API URL."""
+        client = AdvancedChatClient("https://api.example.com/", "token")
+        assert client.api_url == "https://api.example.com"
+        assert client.chat_endpoint == "https://api.example.com/api/assistants/chat"
+    
+    @patch('clementine.advanced_chat_client.requests.post')
+    def test_chat_with_chunks_success(self, mock_post, client):
+        """Test successful chat request with chunks."""
+        # Mock successful response
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {
+            "text_content": "Based on the conversation, they are discussing project updates.",
+            "search_metadata": []
+        }
+        mock_post.return_value = mock_response
+        
+        chunks_request = ChunksRequest(
+            query="What are they talking about?",
+            chunks=["User A: Working on the new feature", "User B: Looks good"],
+            session_id="session-123",
+            client_name="test-client"
+        )
+        
+        result = client.chat_with_chunks(chunks_request)
+        
+        # Verify result
+        assert isinstance(result, TangerineResponse)
+        assert result.text == "Based on the conversation, they are discussing project updates."
+        assert result.metadata == []
+        assert UUID(result.interaction_id)  # Should be valid UUID
+        
+        # Verify API call
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        
+        assert call_args[0][0] == "https://api.example.com/api/assistants/chat"
+        assert call_args[1]["headers"]["Authorization"] == "Bearer test-token"
+        assert call_args[1]["headers"]["Content-Type"] == "application/json"
+        assert call_args[1]["timeout"] == 30
+        
+        # Verify payload
+        payload = call_args[1]["json"]
+        assert payload["assistants"] == ["clowder"]
+        assert payload["query"] == "What are they talking about?"
+        assert payload["chunks"] == ["User A: Working on the new feature", "User B: Looks good"]
+        assert payload["sessionId"] == "session-123"
+        assert payload["client"] == "test-client"
+        assert payload["stream"] is False
+        assert UUID(payload["interactionId"])
+    
+    @patch('clementine.advanced_chat_client.requests.post')
+    def test_chat_with_chunks_timeout_error(self, mock_post, client):
+        """Test timeout error handling."""
+        mock_post.side_effect = requests.exceptions.Timeout()
+        
+        chunks_request = ChunksRequest(
+            query="Test question",
+            chunks=["chunk1"],
+            session_id="session-123",
+            client_name="test-client"
+        )
+        
+        with pytest.raises(requests.exceptions.Timeout):
+            client.chat_with_chunks(chunks_request)
+    
+    @patch('clementine.advanced_chat_client.requests.post')
+    def test_chat_with_chunks_connection_error(self, mock_post, client):
+        """Test connection error handling."""
+        mock_post.side_effect = requests.exceptions.ConnectionError()
+        
+        chunks_request = ChunksRequest(
+            query="Test question",
+            chunks=["chunk1"],
+            session_id="session-123",
+            client_name="test-client"
+        )
+        
+        with pytest.raises(requests.exceptions.ConnectionError):
+            client.chat_with_chunks(chunks_request)
+    
+    @patch('clementine.advanced_chat_client.requests.post')
+    def test_chat_with_chunks_http_error(self, mock_post, client):
+        """Test HTTP error handling."""
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError()
+        mock_response.status_code = 400
+        mock_post.return_value = mock_response
+        
+        chunks_request = ChunksRequest(
+            query="Test question",
+            chunks=["chunk1"],
+            session_id="session-123",
+            client_name="test-client"
+        )
+        
+        with pytest.raises(requests.exceptions.HTTPError):
+            client.chat_with_chunks(chunks_request)
+    
+    @patch('clementine.advanced_chat_client.requests.post')
+    def test_chat_with_chunks_json_decode_error(self, mock_post, client):
+        """Test JSON decode error handling."""
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
+        mock_post.return_value = mock_response
+        
+        chunks_request = ChunksRequest(
+            query="Test question",
+            chunks=["chunk1"],
+            session_id="session-123",
+            client_name="test-client"
+        )
+        
+        with pytest.raises(json.JSONDecodeError):
+            client.chat_with_chunks(chunks_request)

--- a/tests/test_slack_context_extractor.py
+++ b/tests/test_slack_context_extractor.py
@@ -1,0 +1,366 @@
+"""Tests for SlackContextExtractor."""
+
+import pytest
+from unittest.mock import Mock, patch
+from slack_sdk.errors import SlackApiError
+
+from clementine.slack_context_extractor import SlackContextExtractor, SlackMessage
+
+
+class TestSlackMessage:
+    """Test SlackMessage value object."""
+    
+    def test_to_context_string(self):
+        """Test converting message to context string with user ID."""
+        message = SlackMessage(
+            text="Hello world",
+            user_id="U123456",
+            timestamp="1234567890.123"
+        )
+        
+        result = message.to_context_string()
+        assert result == "U123456: Hello world"
+    
+    def test_to_context_string_with_thread(self):
+        """Test converting threaded message to context string."""
+        message = SlackMessage(
+            text="Reply in thread",
+            user_id="U789012",
+            timestamp="1234567890.456",
+            thread_ts="1234567890.123"
+        )
+        
+        result = message.to_context_string()
+        assert result == "U789012: Reply in thread"
+    
+    def test_to_context_string_with_user_name(self):
+        """Test converting message to context string with user name."""
+        message = SlackMessage(
+            text="Hello world",
+            user_id="U123456",
+            timestamp="1234567890.123",
+            user_name="Andrew Chen"
+        )
+        
+        result = message.to_context_string()
+        assert result == "Andrew Chen: Hello world"
+
+
+class TestSlackContextExtractor:
+    """Test SlackContextExtractor functionality."""
+    
+    @pytest.fixture
+    def mock_client(self):
+        """Create mock Slack client."""
+        return Mock()
+    
+    @pytest.fixture
+    def extractor(self, mock_client):
+        """Create SlackContextExtractor with mocked client."""
+        return SlackContextExtractor(mock_client, max_messages=10)
+    
+    def test_init(self, mock_client):
+        """Test initialization."""
+        extractor = SlackContextExtractor(mock_client, max_messages=25)
+        assert extractor.client == mock_client
+        assert extractor.max_messages == 25
+    
+    def test_init_default_max_messages(self, mock_client):
+        """Test initialization with default max_messages."""
+        extractor = SlackContextExtractor(mock_client)
+        assert extractor.max_messages == 50
+    
+    def test_extract_thread_context_success(self, extractor, mock_client):
+        """Test successful thread context extraction."""
+        # Mock API response
+        mock_response = {
+            "messages": [
+                {
+                    "text": "First message",
+                    "user": "U123456",
+                    "ts": "1234567890.123"
+                },
+                {
+                    "text": "Second message",
+                    "user": "U789012",
+                    "ts": "1234567890.456"
+                },
+                {
+                    "text": "Bot message",
+                    "bot_id": "B12345",
+                    "ts": "1234567890.789"
+                }
+            ]
+        }
+        mock_client.conversations_replies.return_value = mock_response
+        
+        # Mock user name lookup to fail so it uses user IDs
+        mock_client.users_info.side_effect = SlackApiError("User not found", response={"error": "user_not_found"})
+        
+        result = extractor.extract_thread_context("C123456", "1234567890.123")
+        
+        # Should filter out bot message  
+        expected = [
+            "U123456: First message",
+            "U789012: Second message"
+        ]
+        assert result == expected
+        
+        # Verify API call
+        mock_client.conversations_replies.assert_called_once_with(
+            channel="C123456",
+            ts="1234567890.123",
+            limit=10
+        )
+    
+    def test_extract_thread_context_slack_error(self, extractor, mock_client):
+        """Test thread context extraction with Slack API error."""
+        mock_client.conversations_replies.side_effect = SlackApiError("API Error", response={"error": "channel_not_found"})
+        
+        result = extractor.extract_thread_context("C123456", "1234567890.123")
+        
+        assert result == []
+    
+    def test_extract_channel_context_success(self, extractor, mock_client):
+        """Test successful channel context extraction."""
+        # Mock API response (newest first, should be reversed)
+        mock_response = {
+            "messages": [
+                {
+                    "text": "Newest message",
+                    "user": "U789012",
+                    "ts": "1234567890.456"
+                },
+                {
+                    "text": "Older message",
+                    "user": "U123456",
+                    "ts": "1234567890.123"
+                }
+            ]
+        }
+        mock_client.conversations_history.return_value = mock_response
+        
+        # Mock user name lookup to fail so it uses user IDs
+        mock_client.users_info.side_effect = SlackApiError("User not found", response={"error": "user_not_found"})
+        
+        result = extractor.extract_channel_context("C123456")
+        
+        # Should be in chronological order (oldest first)
+        expected = [
+            "U123456: Older message",
+            "U789012: Newest message"
+        ]
+        assert result == expected
+        
+        # Verify API call
+        mock_client.conversations_history.assert_called_once_with(
+            channel="C123456",
+            limit=10  # extractor was initialized with max_messages=10
+        )
+    
+    def test_extract_channel_context_with_limit(self, extractor, mock_client):
+        """Test channel context extraction with custom limit."""
+        mock_response = {"messages": []}
+        mock_client.conversations_history.return_value = mock_response
+        
+        extractor.extract_channel_context("C123456", limit=20)
+        
+        mock_client.conversations_history.assert_called_once_with(
+            channel="C123456",
+            limit=20
+        )
+    
+    def test_extract_channel_context_slack_error(self, extractor, mock_client):
+        """Test channel context extraction with Slack API error."""
+        mock_client.conversations_history.side_effect = SlackApiError("API Error", response={"error": "channel_not_found"})
+        
+        result = extractor.extract_channel_context("C123456")
+        
+        assert result == []
+    
+    def test_messages_to_context_filters_bot_messages(self, extractor, mock_client):
+        """Test that bot messages are filtered out."""
+        # Mock user name lookup to fail so it uses user IDs
+        mock_client.users_info.side_effect = SlackApiError("User not found", response={"error": "user_not_found"})
+        
+        messages = [
+            {
+                "text": "Human message",
+                "user": "U123456",
+                "ts": "1234567890.123"
+            },
+            {
+                "text": "Bot message",
+                "bot_id": "B12345",
+                "ts": "1234567890.456"
+            },
+            {
+                "text": "System message",
+                "subtype": "channel_join",
+                "ts": "1234567890.789"
+            }
+        ]
+        
+        result = extractor._messages_to_context(messages)
+        
+        assert result == ["U123456: Human message"]
+    
+    def test_messages_to_context_filters_empty_text(self, extractor, mock_client):
+        """Test that messages without text are filtered out."""
+        # Mock user name lookup to fail so it uses user IDs
+        mock_client.users_info.side_effect = SlackApiError("User not found", response={"error": "user_not_found"})
+        
+        messages = [
+            {
+                "text": "Valid message",
+                "user": "U123456",
+                "ts": "1234567890.123"
+            },
+            {
+                "text": "",
+                "user": "U789012",
+                "ts": "1234567890.456"
+            },
+            {
+                "user": "U111111",  # No text field
+                "ts": "1234567890.789"
+            }
+        ]
+        
+        result = extractor._messages_to_context(messages)
+        
+        assert result == ["U123456: Valid message"]
+    
+    def test_messages_to_context_handles_missing_user(self, extractor):
+        """Test that messages with missing user field use 'unknown'."""
+        messages = [
+            {
+                "text": "Message without user",
+                "ts": "1234567890.123"
+            }
+        ]
+        
+        result = extractor._messages_to_context(messages)
+        
+        assert result == ["unknown: Message without user"]
+    
+    def test_get_user_name_success(self, extractor, mock_client):
+        """Test successful user name lookup."""
+        mock_response = {
+            "user": {
+                "real_name": "Andrew Chen",
+                "profile": {"display_name": "andrew"},
+                "name": "andrew.chen"
+            }
+        }
+        mock_client.users_info.return_value = mock_response
+        
+        result = extractor._get_user_name("U123456")
+        
+        assert result == "Andrew Chen"
+        mock_client.users_info.assert_called_once_with(user="U123456")
+        
+        # Test caching - second call should not hit API
+        result2 = extractor._get_user_name("U123456")
+        assert result2 == "Andrew Chen"
+        assert mock_client.users_info.call_count == 1  # Still only one call
+    
+    def test_get_user_name_fallback_display_name(self, extractor, mock_client):
+        """Test user name lookup fallback to display name."""
+        mock_response = {
+            "user": {
+                "real_name": "",  # No real name
+                "profile": {"display_name": "andrew"},
+                "name": "andrew.chen"
+            }
+        }
+        mock_client.users_info.return_value = mock_response
+        
+        result = extractor._get_user_name("U123456")
+        
+        assert result == "andrew"
+    
+    def test_get_user_name_fallback_username(self, extractor, mock_client):
+        """Test user name lookup fallback to username."""
+        mock_response = {
+            "user": {
+                "real_name": "",  # No real name
+                "profile": {"display_name": ""},  # No display name
+                "name": "andrew.chen"
+            }
+        }
+        mock_client.users_info.return_value = mock_response
+        
+        result = extractor._get_user_name("U123456")
+        
+        assert result == "andrew.chen"
+    
+    def test_get_user_name_api_error(self, extractor, mock_client):
+        """Test user name lookup with API error."""
+        mock_client.users_info.side_effect = SlackApiError("User not found", response={"error": "user_not_found"})
+        
+        result = extractor._get_user_name("U123456")
+        
+        assert result is None
+        
+        # Test caching of failures
+        result2 = extractor._get_user_name("U123456")
+        assert result2 is None
+        assert mock_client.users_info.call_count == 1  # Only called once due to caching
+    
+    def test_get_user_name_invalid_user_id(self, extractor):
+        """Test user name lookup with invalid user ID."""
+        result1 = extractor._get_user_name("")
+        result2 = extractor._get_user_name("unknown")
+        
+        assert result1 is None
+        assert result2 is None
+    
+    def test_extract_context_with_user_names(self, extractor, mock_client):
+        """Test context extraction using real user names."""
+        # Mock conversations API (newest first, as Slack returns)
+        mock_conversations_response = {
+            "messages": [
+                {
+                    "text": "How's the project going?",
+                    "user": "U789012",
+                    "ts": "1234567890.456"
+                },
+                {
+                    "text": "Hello everyone",
+                    "user": "U123456",
+                    "ts": "1234567890.123"
+                }
+            ]
+        }
+        mock_client.conversations_history.return_value = mock_conversations_response
+        
+        # Mock user info API
+        def mock_users_info(user):
+            if user == "U123456":
+                return {
+                    "user": {
+                        "real_name": "Andrew Chen",
+                        "profile": {"display_name": "andrew"},
+                        "name": "andrew.chen"
+                    }
+                }
+            elif user == "U789012":
+                return {
+                    "user": {
+                        "real_name": "Psav Kumar",
+                        "profile": {"display_name": "psav"},
+                        "name": "psav.kumar"
+                    }
+                }
+        
+        mock_client.users_info.side_effect = mock_users_info
+        
+        result = extractor.extract_channel_context("C123456")
+        
+        # Should use real names in chronological order (oldest first)
+        expected = [
+            "Andrew Chen: Hello everyone",
+            "Psav Kumar: How's the project going?"
+        ]
+        assert result == expected

--- a/tests/test_slack_question_bot.py
+++ b/tests/test_slack_question_bot.py
@@ -1,0 +1,277 @@
+"""Tests for SlackQuestionBot."""
+
+import pytest
+from unittest.mock import Mock, patch
+from slack_sdk.web.client import WebClient
+
+from clementine.slack_question_bot import SlackQuestionBot
+from clementine.slack_client import SlackClient
+from clementine.slack_context_extractor import SlackContextExtractor
+from clementine.advanced_chat_client import AdvancedChatClient, ChunksRequest
+from clementine.tangerine import TangerineResponse
+from clementine.formatters import MessageFormatter
+from clementine.error_handling import ErrorHandler
+
+
+class TestSlackQuestionBot:
+    """Test SlackQuestionBot functionality."""
+    
+    @pytest.fixture
+    def mock_slack_client(self):
+        """Create mock SlackClient."""
+        return Mock(spec=SlackClient)
+    
+    @pytest.fixture
+    def mock_context_extractor(self):
+        """Create mock SlackContextExtractor."""
+        return Mock(spec=SlackContextExtractor)
+    
+    @pytest.fixture
+    def mock_advanced_chat_client(self):
+        """Create mock AdvancedChatClient."""
+        return Mock(spec=AdvancedChatClient)
+    
+    @pytest.fixture
+    def mock_formatter(self):
+        """Create mock ResponseFormatter."""
+        return Mock(spec=MessageFormatter)
+    
+    @pytest.fixture
+    def mock_slack_web_client(self):
+        """Create mock Slack WebClient."""
+        return Mock(spec=WebClient)
+    
+    @pytest.fixture
+    def bot(self, mock_slack_client, mock_context_extractor, mock_advanced_chat_client, mock_formatter):
+        """Create SlackQuestionBot for testing."""
+        return SlackQuestionBot(
+            slack_client=mock_slack_client,
+            context_extractor=mock_context_extractor,
+            advanced_chat_client=mock_advanced_chat_client,
+            bot_name="TestBot",
+            formatter=mock_formatter
+        )
+    
+    def test_init(self, mock_slack_client, mock_context_extractor, mock_advanced_chat_client):
+        """Test initialization."""
+        bot = SlackQuestionBot(
+            slack_client=mock_slack_client,
+            context_extractor=mock_context_extractor,
+            advanced_chat_client=mock_advanced_chat_client,
+            bot_name="TestBot"
+        )
+        
+        assert bot.slack_client == mock_slack_client
+        assert bot.context_extractor == mock_context_extractor
+        assert bot.advanced_chat_client == mock_advanced_chat_client
+        assert bot.bot_name == "TestBot"
+        assert isinstance(bot.formatter, MessageFormatter)  # default
+        assert isinstance(bot.error_handler, ErrorHandler)
+    
+    def test_handle_question_success_with_thread(self, bot, mock_slack_client, mock_context_extractor, 
+                                                 mock_advanced_chat_client, mock_formatter, mock_slack_web_client):
+        """Test successful question handling with thread context."""
+        # Setup mocks
+        mock_slack_client.post_loading_message.return_value = "loading_ts_123"
+        mock_context_extractor.extract_thread_context.return_value = [
+            "User A: Working on the feature",
+            "User B: Looks good to me"
+        ]
+        
+        mock_response = TangerineResponse(
+            text="They are discussing feature development.",
+            metadata=[],
+            interaction_id="interaction_123"
+        )
+        mock_advanced_chat_client.chat_with_chunks.return_value = mock_response
+        mock_formatter.format_with_sources.return_value = "Formatted response"
+        
+        # Execute
+        bot.handle_question(
+            question="What are they talking about?",
+            channel="C123456",
+            thread_ts="1234567890.123",
+            user_id="U123456",
+            slack_web_client=mock_slack_web_client
+        )
+        
+        # Verify calls
+        mock_slack_client.post_loading_message.assert_called_once_with("C123456", "1234567890.123")
+        mock_context_extractor.extract_thread_context.assert_called_once_with("C123456", "1234567890.123")
+        mock_context_extractor.extract_channel_context.assert_not_called()
+        
+        # Verify advanced chat client call
+        mock_advanced_chat_client.chat_with_chunks.assert_called_once()
+        call_args = mock_advanced_chat_client.chat_with_chunks.call_args[0][0]
+        assert isinstance(call_args, ChunksRequest)
+        assert call_args.query == "What are they talking about?"
+        assert call_args.chunks == ["User A: Working on the feature", "User B: Looks good to me"]
+        assert call_args.client_name == "TestBot"
+        
+        mock_formatter.format_with_sources.assert_called_once_with(mock_response)
+        mock_slack_client.update_message.assert_called_once_with("C123456", "loading_ts_123", "Formatted response")
+    
+    def test_handle_question_success_without_thread(self, bot, mock_slack_client, mock_context_extractor, 
+                                                   mock_advanced_chat_client, mock_formatter, mock_slack_web_client):
+        """Test successful question handling without thread context (channel history)."""
+        # Setup mocks
+        mock_slack_client.post_loading_message.return_value = "loading_ts_123"
+        mock_context_extractor.extract_channel_context.return_value = [
+            "User A: Good morning",
+            "User B: How's the project going?"
+        ]
+        
+        mock_response = TangerineResponse(
+            text="They are having a morning check-in about the project.",
+            metadata=[],
+            interaction_id="interaction_123"
+        )
+        mock_advanced_chat_client.chat_with_chunks.return_value = mock_response
+        mock_formatter.format_with_sources.return_value = "Formatted response"
+        
+        # Execute
+        bot.handle_question(
+            question="What's the conversation about?",
+            channel="C123456",
+            thread_ts=None,  # No thread
+            user_id="U123456",
+            slack_web_client=mock_slack_web_client
+        )
+        
+        # Verify calls
+        mock_slack_client.post_loading_message.assert_called_once_with("C123456", None)
+        mock_context_extractor.extract_channel_context.assert_called_once_with("C123456")
+        mock_context_extractor.extract_thread_context.assert_not_called()
+        
+        # Verify advanced chat client call
+        mock_advanced_chat_client.chat_with_chunks.assert_called_once()
+        call_args = mock_advanced_chat_client.chat_with_chunks.call_args[0][0]
+        assert call_args.chunks == ["User A: Good morning", "User B: How's the project going?"]
+    
+    def test_handle_question_no_loading_message(self, bot, mock_slack_client, mock_slack_web_client):
+        """Test handling when loading message fails to post."""
+        mock_slack_client.post_loading_message.return_value = None
+        
+        bot.handle_question(
+            question="Test question",
+            channel="C123456",
+            thread_ts="1234567890.123",
+            user_id="U123456",
+            slack_web_client=mock_slack_web_client
+        )
+        
+        # Should return early without further processing
+        mock_slack_client.post_loading_message.assert_called_once()
+        # No other methods should be called
+        assert not hasattr(mock_slack_client, 'update_message') or not mock_slack_client.update_message.called
+    
+    def test_handle_question_no_context(self, bot, mock_slack_client, mock_context_extractor, mock_slack_web_client):
+        """Test handling when no context is available."""
+        mock_slack_client.post_loading_message.return_value = "loading_ts_123"
+        mock_context_extractor.extract_thread_context.return_value = []  # No context
+        
+        bot.handle_question(
+            question="What are they talking about?",
+            channel="C123456",
+            thread_ts="1234567890.123",
+            user_id="U123456",
+            slack_web_client=mock_slack_web_client
+        )
+        
+        # Should update message with error
+        mock_slack_client.update_message.assert_called_once_with(
+            "C123456", 
+            "loading_ts_123", 
+            "I couldn't find any recent conversation context to answer your question about."
+        )
+    
+    def test_handle_question_exception_handling(self, bot, mock_slack_client, mock_context_extractor, 
+                                               mock_slack_web_client):
+        """Test exception handling during question processing."""
+        mock_slack_client.post_loading_message.return_value = "loading_ts_123"
+        mock_context_extractor.extract_thread_context.side_effect = Exception("API Error")
+        
+        bot.handle_question(
+            question="Test question",
+            channel="C123456",
+            thread_ts="1234567890.123",
+            user_id="U123456",
+            slack_web_client=mock_slack_web_client
+        )
+        
+        # Should update message with error
+        mock_slack_client.update_message.assert_called_once()
+        call_args = mock_slack_client.update_message.call_args[0]
+        assert call_args[0] == "C123456"
+        assert call_args[1] == "loading_ts_123"
+        assert "TestBot hit a snag" in call_args[2]  # Error message from ErrorHandler
+    
+    def test_handle_question_with_block_kit_response(self, bot, mock_slack_client, mock_context_extractor, 
+                                                    mock_advanced_chat_client, mock_formatter, mock_slack_web_client):
+        """Test handling with Block Kit formatted response."""
+        # Setup mocks
+        mock_slack_client.post_loading_message.return_value = "loading_ts_123"
+        mock_context_extractor.extract_thread_context.return_value = ["User A: Hello"]
+        
+        mock_response = TangerineResponse(text="Response", metadata=[], interaction_id="123")
+        mock_advanced_chat_client.chat_with_chunks.return_value = mock_response
+        
+        # Mock formatter returns Block Kit format
+        mock_formatter.format_with_sources.return_value = {
+            "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "Response"}}],
+            "text": "Response"
+        }
+        
+        # Execute
+        bot.handle_question(
+            question="Test",
+            channel="C123456", 
+            thread_ts="1234567890.123",
+            user_id="U123456",
+            slack_web_client=mock_slack_web_client
+        )
+        
+        # Should call update_message_with_blocks instead of update_message
+        mock_slack_client.update_message_with_blocks.assert_called_once()
+        mock_slack_client.update_message.assert_not_called()
+    
+    @patch('clementine.slack_question_bot.generate_session_id')
+    def test_get_chat_response_session_id_generation(self, mock_generate_session_id, bot, mock_advanced_chat_client):
+        """Test session ID generation for chat response."""
+        mock_generate_session_id.return_value = "generated_session_id"
+        
+        mock_response = TangerineResponse(text="Response", metadata=[], interaction_id="123")
+        mock_advanced_chat_client.chat_with_chunks.return_value = mock_response
+        
+        result = bot._get_chat_response(
+            question="Test question",
+            context_chunks=["chunk1", "chunk2"],
+            channel="C123456",
+            thread_ts="1234567890.123"
+        )
+        
+        # Verify session ID generation
+        mock_generate_session_id.assert_called_once_with("C123456", "1234567890.123")
+        
+        # Verify chat call
+        mock_advanced_chat_client.chat_with_chunks.assert_called_once()
+        call_args = mock_advanced_chat_client.chat_with_chunks.call_args[0][0]
+        assert call_args.session_id == "generated_session_id"
+    
+    @patch('clementine.slack_question_bot.generate_session_id')
+    def test_get_chat_response_no_thread(self, mock_generate_session_id, bot, mock_advanced_chat_client):
+        """Test session ID generation when no thread timestamp."""
+        mock_generate_session_id.return_value = "generated_session_id"
+        
+        mock_response = TangerineResponse(text="Response", metadata=[], interaction_id="123")
+        mock_advanced_chat_client.chat_with_chunks.return_value = mock_response
+        
+        bot._get_chat_response(
+            question="Test question",
+            context_chunks=["chunk1"],
+            channel="C123456",
+            thread_ts=None
+        )
+        
+        # Should use channel as fallback for session ID
+        mock_generate_session_id.assert_called_once_with("C123456", "C123456")

--- a/tests/test_tangerine.py
+++ b/tests/test_tangerine.py
@@ -102,6 +102,38 @@ class TestTangerineClient:
         assert result.text == "Hello response"
         assert len(result.metadata) == 1
     
+    def test_chat_payload_includes_disable_agentic(self):
+        """Test that chat payload includes disable_agentic=True."""
+        captured_payload = {}
+        
+        def mock_make_request(payload):
+            captured_payload.update(payload)
+            return {
+                "text_content": "Test response",
+                "search_metadata": []
+            }
+        
+        client = TangerineClient("http://api.example.com", "token123")
+        client._make_request = mock_make_request
+        
+        client.chat(
+            assistants=["assistant1"],
+            query="Test query",
+            session_id="session123",
+            client_name="TestBot",
+            prompt="Test prompt"
+        )
+        
+        # Verify disable_agentic is included and set to True
+        assert "disable_agentic" in captured_payload
+        assert captured_payload["disable_agentic"] is True
+        
+        # Verify other expected fields are still present
+        assert captured_payload["assistants"] == ["assistant1"]
+        assert captured_payload["query"] == "Test query"
+        assert captured_payload["prompt"] == "Test prompt"
+        assert captured_payload["stream"] is False
+    
     def test_initialization_validation(self):
         """Test client initialization validation."""
         with pytest.raises(ValueError, match="Both api_url and api_token are required"):


### PR DESCRIPTION
This PR adds a new slash command

`/clementine slack`

That allows users to do a sort of "RAG for slack" workflow asking questions about what is going on in slack.