### PR TITLE
Support no_persist_chunks API option

### DIFF
--- a/app.py
+++ b/app.py
@@ -303,14 +303,14 @@ def handle_clementine_command(ack, body, client):
             user_id = body.get("user_id")
             
             # For slash commands, there's no thread context, so we'll use channel history
-            # Use ephemeral=True to make responses visible only to the user who issued the command
+            # Use no_persist_chunks=True to prevent storing chunks for slash command responses
             slack_question_bot.handle_question(
                 question=question,
                 channel=channel_id,
                 thread_ts=None,  # No thread for slash commands
                 user_id=user_id,
                 slack_web_client=client,
-                ephemeral=True  # Slash command responses are private to the user
+                no_persist_chunks=True  # Slash command responses don't persist chunks
             )
         else:
             # Show help text for unknown commands

--- a/clementine/advanced_chat_client.py
+++ b/clementine/advanced_chat_client.py
@@ -23,6 +23,7 @@ class ChunksRequest:
     user_prompt: str
     assistants: List[str] = None
     model: str = None
+    no_persist_chunks: bool = False
     
     def __post_init__(self):
         """Set default assistants if none provided."""
@@ -49,6 +50,10 @@ class ChunksRequest:
         # Add model if specified
         if self.model:
             payload["model"] = self.model
+        
+        # Add no_persist_chunks if enabled (for slack slash commands)
+        if self.no_persist_chunks:
+            payload["no_persist_chunks"] = True
             
         return payload
 

--- a/tests/test_slack_question_bot.py
+++ b/tests/test_slack_question_bot.py
@@ -234,7 +234,7 @@ class TestSlackQuestionBot:
         assert call_args[0] == "C123456"
         assert call_args[1] == "loading_ts_123"
         assert "TestBot hit a snag" in call_args[2]  # Error message from ErrorHandler
-        assert call_args[3] is None  # user_id should be None for non-ephemeral
+        assert call_args[3] is None  # user_id should be None for non-slash-command
     
     def test_handle_question_with_block_kit_response(self, bot, mock_slack_client, mock_context_extractor, 
                                                     mock_advanced_chat_client, mock_formatter, mock_slack_web_client):
@@ -264,12 +264,12 @@ class TestSlackQuestionBot:
         # Should call update_message_with_blocks instead of update_message
         mock_slack_client.update_message_with_blocks.assert_called_once()
         call_args = mock_slack_client.update_message_with_blocks.call_args[0]
-        assert call_args[3] is None  # user_id should be None for non-ephemeral
+        assert call_args[3] is None  # user_id should be None for non-slash-command
         mock_slack_client.update_message.assert_not_called()
     
-    def test_handle_question_ephemeral_mode(self, bot, mock_slack_client, mock_context_extractor, 
+    def test_handle_question_no_persist_chunks_mode(self, bot, mock_slack_client, mock_context_extractor, 
                                            mock_advanced_chat_client, mock_formatter, mock_slack_web_client):
-        """Test ephemeral mode for slash commands."""
+        """Test no_persist_chunks mode for slash commands."""
         # Setup mocks
         mock_slack_client.post_loading_message.return_value = "loading_ts_123"
         mock_context_extractor.extract_thread_context.return_value = ["User A: Working on feature"]
@@ -282,14 +282,14 @@ class TestSlackQuestionBot:
         mock_advanced_chat_client.chat_with_chunks.return_value = mock_response
         mock_formatter.format_with_sources.return_value = "Formatted response"
         
-        # Execute with ephemeral=True
+        # Execute with no_persist_chunks=True
         bot.handle_question(
             question="What are they talking about?",
             channel="C123456",
             thread_ts="1234567890.123",
             user_id="U123456",
             slack_web_client=mock_slack_web_client,
-            ephemeral=True  # This should make responses private
+            no_persist_chunks=True  # This should make responses private and not persist chunks
         )
         
         # Verify that user_id is passed to make messages ephemeral


### PR DESCRIPTION
Tangerine now has a no_persist_chunks API option. We use this to make it sure slack context doesn't get stored in the database.